### PR TITLE
The get-pip.py script for py 2.7 moved slightly

### DIFF
--- a/cookbooks/swift/recipes/setup.rb
+++ b/cookbooks/swift/recipes/setup.rb
@@ -89,7 +89,7 @@ if node['use_python3']
   pip_url = 'https://bootstrap.pypa.io/get-pip.py'
 else
   default_python = 'python2'
-  pip_url = 'https://bootstrap.pypa.io/2.7/get-pip.py'
+  pip_url = 'https://bootstrap.pypa.io/pip/2.7/get-pip.py'
 end
 
 execute "select default python version" do


### PR DESCRIPTION
This patch changes the setup recipe to point to the correct location.