### PR TITLE
Fix PyKMIP on jammy

### DIFF
--- a/cookbooks/swift/templates/default/etc/pykmip/server.conf.erb
+++ b/cookbooks/swift/templates/default/etc/pykmip/server.conf.erb
@@ -8,8 +8,4 @@ auth_suite=TLS1.2
 policy_path=/etc/pykmip/policies
 database_path=/var/lib/pykmip/pykmip.db
 enable_tls_client_auth=False
-tls_cipher_suites=
-    TLS_RSA_WITH_AES_128_CBC_SHA256
-    TLS_RSA_WITH_AES_256_CBC_SHA256
-    TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
 logging_level=DEBUG


### PR DESCRIPTION
We were hardcoding TLS ciphers that no longer work (by default?) on jammy.