### PR TITLE
Enable rsync on jammy

### DIFF
--- a/cookbooks/swift/recipes/configs.rb
+++ b/cookbooks/swift/recipes/configs.rb
@@ -12,10 +12,17 @@ template "/etc/rsyncd.conf" do
   })
 end
 
-execute "enable-rsync" do
-  command "sed -i 's/ENABLE=false/ENABLE=true/' /etc/default/rsync"
-  not_if "grep ENABLE=true /etc/default/rsync"
-  action :run
+if node['platform_version'] == '22.04' then
+  execute "enable-rsync" do
+    command "systemctl enable rsync.service"
+    action :run
+  end
+else
+  execute "enable-rsync" do
+    command "sed -i 's/ENABLE=false/ENABLE=true/' /etc/default/rsync"
+    not_if "grep ENABLE=true /etc/default/rsync"
+    action :run
+  end
 end
 
 # pre device rsync modules


### PR DESCRIPTION
Otherwise, you aren't ready to run probe tests following a reload.

For example, try running
```
vagrant destroy -f ; vagrant up ; vagrant reload ; vagrant ssh -c 'cd swift && pytest -x test/probe'
```
before/after the change; before, you'll see a bunch of
```
SKIPPED (unable to connect to rsync export {replication_ip}::account_{device} (rsync 127.0.0.1::account_sdb1))
```