### PR TITLE
fix clean deployment

### DIFF
--- a/cookbooks/swift/recipes/configs.rb
+++ b/cookbooks/swift/recipes/configs.rb
@@ -111,6 +111,10 @@ execute "install cert" do
   creates "/usr/local/share/ca-certificates/extra/saio_ca.crt"
 end
 
+execute "fix certifi" do
+  command "cat #{node['saio_crt_path']} >> $(python -m certifi)"
+end
+
 execute "create pem" do
   command "cat saio.crt saio.key > saio.pem"
   cwd "/etc/ssl/private/"

--- a/cookbooks/swift/recipes/source.rb
+++ b/cookbooks/swift/recipes/source.rb
@@ -107,6 +107,7 @@ end
 # N.B. the saio_crt_path is coupled with "create cert" task in configs.rb
 # yes, we this file exists even if you have node['ssl'] == false
 execute "fix certifi" do
+  only_if { ::File.exist?(node['saio_crt_path']) }
   command "cat #{node['saio_crt_path']} >> $(python -m certifi)"
 end
 


### PR DESCRIPTION
fixes #154

Running vagrant up was failing when there was no existing VM.
The "fix certifi" task in `source.rb` requires the certificate, which is
not created until the "create cert" task in `config.rb` later in the process.

This change ensures that the VM creates successfully by making the
"fix certifi" task in `source.rb` conditional on the certificate existing.

It also restores the "fix certifi" task to config.rb so that it is run both
on provision, and with the `reinstallswift` script.