### PR TITLE
Add /.scratch folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ localrc*
 /isa-l
 /pyeclib
 /swift-zipkin
+/.scratch


### PR DESCRIPTION
This folder is useful for local development and testing e.g. making changes to nv-swift-gizmos.