### PR TITLE
Set allow_open_expired = true by default in vsaio

### DIFF
--- a/cookbooks/swift/templates/default/etc/swift/internal-client.conf.erb
+++ b/cookbooks/swift/templates/default/etc/swift/internal-client.conf.erb
@@ -29,6 +29,7 @@ pipeline = catch_errors proxy-logging cache symlink <%= @keymaster_pipeline %> e
 [app:proxy-server]
 use = egg:swift#proxy
 account_autocreate = True
+allow_open_expired = True
 
 [filter:symlink]
 use = egg:swift#symlink

--- a/cookbooks/swift/templates/default/etc/swift/proxy-server/default.conf-template.erb
+++ b/cookbooks/swift/templates/default/etc/swift/proxy-server/default.conf-template.erb
@@ -61,6 +61,7 @@ storage_domain = saio
 use = egg:swift#proxy
 allow_account_management = true
 account_autocreate = true
+allow_open_expired = true
 
 [filter:kmip_keymaster]
 use = egg:swift#kmip_keymaster


### PR DESCRIPTION
This will facilitate `test swift-integrity delete --dry-run` to correctly detect unreaped/expired objects correctly by default.

Testing:
```
cchigbo@cchigbo-mlt vagrant-swift-all-in-one % vagrant destroy
cchigbo@cchigbo-mlt vagrant-swift-all-in-one % vagrant ssh
vagrant@vagrant:~$ cat /etc/swift/internal-client.conf # verified that the line  allow_open_expired = True
vagrant@vagrant:~$ cat /etc/swift/proxy-server/default.conf-template # verified that the line allow_open_expired = true was present
```