### PR TITLE
let new non swift_* labeled metrics through

### DIFF
--- a/cookbooks/swift/files/default/etc/prometheus/statsd_mapping.yaml
+++ b/cookbooks/swift/files/default/etc/prometheus/statsd_mapping.yaml
@@ -419,8 +419,8 @@ mappings:
           name: "$2"
           type: "timer"
 
-      ### new metrics we're missing that aren't prefixed with a '*.net' hostname
-      - match: (.*)
+      ### new "legacy" metrics that use the "dotted label" format
+      - match: (^.*\..*$)
         match_type: regex
         match_metric_type: counter
         name: "unknown_raw_metric_counter"
@@ -428,7 +428,7 @@ mappings:
           name: "$1"
           type: "counter"
 
-      - match: (.*)
+      - match: (^.*\..*$)
         match_type: regex
         match_metric_type: gauge
         name: "unknown_raw_metric_gauge"
@@ -436,7 +436,7 @@ mappings:
           name: "$1"
           type: "gauge"
 
-      - match: (.*)
+      - match: (^.*\..*$)
         match_type: regex
         match_metric_type: timer
         name: "unknown_raw_metric_timer"
@@ -444,7 +444,7 @@ mappings:
           name: "$1"
           type: "timer"
 
-      - match: (.*)
+      - match: (^.*\..*$)
         match_type: regex
         name: "unknown_raw_metric_other"
         labels:


### PR DESCRIPTION
We're instrumenting some mw who's labeled metrics won't start with swift_

When testing labeled metrics in a vsaio I don't think that "any metric we don't know" is the right scope for the prom exporter - really only metrics that are trying to use "dots" in the name to mean *labels* should be flagged up to have their fields parsed/annotated

... and hopefully there won't be much more of that going on.  For any NEW metric we're adding to swift (or else where) it should hopefully use the labeled format and tell us what the field names are explicitly!

FWIW the metric in question was showing up in my vsaio prom like this before:

```
unknown_raw_metric_counter{event="handle_request", host="proxy", instance="localhost:9100", job="saio", method="GET", name="s8ka_request", scope="authen", type="counter"}
```

^ which was already kind of "silly" - an "unknown" metric with labels!?

```
s8ka_request{event="handle_request", host="proxy", instance="localhost:9100", job="saio", method="GET", scope="authen"}
```

^ and now it's just like this - which I think it totally reasonable.

There may be a different way to spell this in the prom mapping file (any metric that doesn't have labels?) - but I think "any metric that's using dots" is probably good enough to catch basically any legacy metric and still let native labeled metrics through (unless you added a `braindead.` prefix to all your labled metrics!?)

